### PR TITLE
Do not merge Contentful fields with properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ you can use the tag ``{% language_switcher %}`` in your templates to insert a li
 
 
 #### Content Fields:
-All Entry fields can be used inside the layout templates as {{ page.fieldname }}
+All Entry fields can be used inside the layout templates as {{ page.contentful_fields.fieldname }}
   
 #### ULRs and Layouts: 
   

--- a/lib/jekyll-contentful.rb
+++ b/lib/jekyll-contentful.rb
@@ -20,6 +20,9 @@ module Jekyll
       fields = entry.fields.inject({}){|x,(k,v)| x[k.to_s] = v; x}
       self.data['fields'] = fields
 
+      display_field = entry.content_type.resolve.display_field
+      self.data['title'] = fields[display_field] if display_field
+
       self.data["contentful_id"] = entry.id
       self.data["locale"] = entry.locale
 

--- a/lib/jekyll-contentful.rb
+++ b/lib/jekyll-contentful.rb
@@ -18,13 +18,13 @@ module Jekyll
 
       # stringify hash keys
       fields = entry.fields.inject({}){|x,(k,v)| x[k.to_s] = v; x}
-      self.data['fields'] = fields
+      self.data['contentful_fields'] = fields
 
       display_field = entry.content_type.resolve.display_field
       self.data['title'] = fields[display_field] if display_field
 
       self.data["contentful_id"] = entry.id
-      self.data["locale"] = entry.locale
+      self.data["contentful_locale"] = entry.locale
 
       # If there is a title fields make it the url
       page_title_slug = Utils.slugify(self.data["title"] || "")

--- a/lib/jekyll-contentful.rb
+++ b/lib/jekyll-contentful.rb
@@ -18,9 +18,7 @@ module Jekyll
 
       # stringify hash keys
       fields = entry.fields.inject({}){|x,(k,v)| x[k.to_s] = v; x}
-
-      # merge data
-      self.data.merge!(fields)
+      self.data['fields'] = fields
 
       self.data["contentful_id"] = entry.id
       self.data["locale"] = entry.locale


### PR DESCRIPTION
This ensures that all fields are actually accessible, no matter if they clash with existing system defined properties, e.g. `content`.
